### PR TITLE
Fix recurring work order bug

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -54,7 +54,11 @@ def register():
 
 def process_recurring_workorders():
     """Create next work order for completed recurring tasks."""
-    for wo in WorkOrder.query.filter(WorkOrder.recurring_interval_days != None, WorkOrder.status == 'Completed').all():
+    for wo in WorkOrder.query.filter(
+        WorkOrder.recurring_interval_days != None,
+        WorkOrder.status == 'Completed',
+        WorkOrder.due_date != None,
+    ).all():
         next_due = wo.due_date + timedelta(days=wo.recurring_interval_days)
         exists = WorkOrder.query.filter_by(
             asset_id=wo.asset_id,


### PR DESCRIPTION
## Summary
- avoid crashing when recurring work orders lack a due date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2afe4914832e8f379e25a9f5a9fe